### PR TITLE
Updated URL for Elite-C holder

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ Components necessary:
 | Part name                         | Amount (4x6) | Amount (3x5) | Link                                                                                       |
 | --------------------------------- | ------------ | ------------ | ------------------------------------------------------------------------------------------ |
 | Elite-C                           | 2            | 2            |                                                                                            |
-| Elite-C adapter for the Charybdis | 2            | 2            | https://github.com/Bastardkb/mcu-imprint-charybdis                                         |
+| Elite-C adapter for the Charybdis | 2            | 2            | https://github.com/Bastardkb/Elite-C-holder                                         |
 | Cables                            |              |              | 28 AWG recommended                                                                         |
 | Audio jack, SMD                   | 2            | 2            |                                                                                            |
 | Button, 4x4x1.5                   | 2            | 2            | https://www.aliexpress.com/item/1005001304569553.html?spm=a2g0s.9042311.0.0.27424c4dDwgcp7 |


### PR DESCRIPTION
Very simple change, the URL for the elite-C holder points to a holder that says it is outdated.